### PR TITLE
fix: Auth Redirect

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import axios, { isCancel } from "axios";
 import { App } from "@/App.tsx";
+import { UserStore } from "@/stores/User.ts";
 
 /**
  * In StrictMode, we sometimes get double renderings that call 2 APIs, but the load API is called so quickly that it
@@ -21,6 +22,10 @@ addEventListener("unhandledrejection", (event) => {
 axios.interceptors.response.use(undefined, (error) => {
 	if (isCancel(error)) {
 		return false;
+	}
+	if (error.response.status === 401) {
+		// Quick hack that will redirect to login
+		UserStore.setSnapshot({});
 	}
 	throw error;
 });

--- a/ui/src/stores/User.ts
+++ b/ui/src/stores/User.ts
@@ -16,9 +16,7 @@ const cookies = new Cookies(null, {
 });
 
 class User extends BaseStore<IUser> {
-	snapshot = {
-		loading: true,
-	} as IUser;
+	snapshot = {} as IUser;
 
 	constructor() {
 		super();
@@ -60,6 +58,9 @@ class User extends BaseStore<IUser> {
 	async load() {
 		this.abort();
 		try {
+			this.setSnapshot({
+				loading: true,
+			});
 			await AuthAPI.getProfile({
 				signal: this.apiController.signal,
 			});


### PR DESCRIPTION
- Whenever we receive a 401 from an Axios call, we unset the user's token, which will trigger to redirect to login page
- Fixing issue with loading page always showing if no cookie present